### PR TITLE
Implement session caching and refine proxy cache

### DIFF
--- a/backend/src/api/cache.rs
+++ b/backend/src/api/cache.rs
@@ -39,3 +39,45 @@ impl Cache {
 }
 
 pub static PROXY_CACHE: Lazy<Cache> = Lazy::new(|| Cache::new());
+
+use crate::api::cookie::SessionData;
+
+#[derive(Clone)]
+pub struct CachedSession {
+    pub data: SessionData,
+    pub inserted: Instant,
+}
+
+pub struct SessionCache {
+    inner: LockWithTimeout<HashMap<String, CachedSession>>,
+}
+
+impl SessionCache {
+    pub fn new() -> Self {
+        Self {
+            inner: LockWithTimeout::new(HashMap::new()),
+        }
+    }
+
+    pub async fn get(&self, key: &str, ttl: Duration) -> Option<SessionData> {
+        let guard = self.inner.try_read().await.ok()?;
+        guard
+            .get(key)
+            .filter(|c| c.inserted.elapsed() < ttl)
+            .map(|c| c.data.clone())
+    }
+
+    pub async fn insert(&self, key: String, data: SessionData) {
+        if let Ok(mut guard) = self.inner.try_write().await {
+            guard.insert(
+                key,
+                CachedSession {
+                    data,
+                    inserted: Instant::now(),
+                },
+            );
+        }
+    }
+}
+
+pub static SESSION_CACHE: Lazy<SessionCache> = Lazy::new(|| SessionCache::new());


### PR DESCRIPTION
## Summary
- avoid expensive session lookups by adding a session cache
- add longer TTL caching for `/logs` and `/usage` endpoints
- keep VM status requests uncached
- provide helper to fetch sessions from cache before hitting DB

## Testing
- `cargo build --manifest-path backend/Cargo.toml --quiet`
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68434b981594832d8efa2dff6253f27b