### PR TITLE
Add global app state for caching and clients

### DIFF
--- a/backend/src/api/cache.rs
+++ b/backend/src/api/cache.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use artisan_middleware::dusa_collection_utils::core::types::rwarc::LockWithTimeout;
-use once_cell::sync::Lazy;
 
 #[derive(Clone)]
 pub struct CachedResponse {
@@ -37,8 +36,6 @@ impl Cache {
         }
     }
 }
-
-pub static PROXY_CACHE: Lazy<Cache> = Lazy::new(|| Cache::new());
 
 use crate::api::cookie::SessionData;
 
@@ -78,7 +75,7 @@ impl SessionCache {
             );
         }
     }
-  
+
     pub async fn remove(&self, key: &str) {
         if let Ok(mut guard) = self.inner.try_write().await {
             guard.remove(key);
@@ -91,5 +88,3 @@ impl SessionCache {
         }
     }
 }
-
-pub static SESSION_CACHE: Lazy<SessionCache> = Lazy::new(|| SessionCache::new());

--- a/backend/src/api/cookie.rs
+++ b/backend/src/api/cookie.rs
@@ -1,9 +1,9 @@
+use crate::state::get_state;
 use artisan_middleware::{
     api::token::SimpleLoginRequest,
     dusa_collection_utils::{core::logger::LogLevel, log},
 };
 use chrono::{DateTime, Utc};
-use reqwest::Client;
 use sqlx::Row;
 use uuid::Uuid;
 
@@ -11,7 +11,6 @@ use crate::database::connection::get_db_pool;
 
 use super::helper::{get_base_url, peek_exp_from_jwt_unverified, peek_sub_from_jwt_unverified};
 use serde::{Deserialize, Serialize};
-
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SessionData {
@@ -50,8 +49,7 @@ pub async fn login(request: SimpleLoginRequest) -> Result<SessionData, String> {
         request.email
     );
 
-
-    let client = Client::new();
+    let client = get_state().http_client.clone();
 
     // Log that we are about to send the HTTP request.
     log!(
@@ -222,7 +220,11 @@ pub async fn lookup_session(
             ()
         })?;
         let expires_at: DateTime<Utc> = r.try_get("expires_at").map_err(|e| {
-            log!(LogLevel::Error, "lookup_session column expires_at error: {}", e);
+            log!(
+                LogLevel::Error,
+                "lookup_session column expires_at error: {}",
+                e
+            );
             ()
         })?;
 

--- a/backend/src/api/handler.rs
+++ b/backend/src/api/handler.rs
@@ -1,4 +1,5 @@
-use crate::api::cache::{CachedResponse, PROXY_CACHE, SESSION_CACHE};
+use crate::api::cache::CachedResponse;
+use crate::state::get_state;
 use crate::{
     api::{common::PortalRejection::Whoops, helper::get_base_url},
     auth::token::get_token,
@@ -11,7 +12,6 @@ use artisan_middleware::{
 };
 use bytes::Bytes;
 use cookie::CookieBuilder;
-use reqwest::Client;
 use serde_json::Value as JsonValue;
 use std::time::{Duration, Instant};
 use warp::hyper::Body;
@@ -90,7 +90,7 @@ pub async fn logout_handler(session: SessionData) -> Result<impl warp::Reply, wa
         // don't send an error so the frontend still clears the cookie
     }
 
-    SESSION_CACHE.remove(&session.session_id).await;
+    get_state().session_cache.remove(&session.session_id).await;
 
     // Build a “clear cookie”:
     let clear = cookie::Cookie::build("session_id")
@@ -120,7 +120,10 @@ pub async fn logout_all_handler(session: SessionData) -> Result<impl warp::Reply
         log!(LogLevel::Error, "Error deleting sessions from DB: {}", e);
     }
 
-    SESSION_CACHE.remove_user(&session.user_id).await;
+    get_state()
+        .session_cache
+        .remove_user(&session.user_id)
+        .await;
 
     let clear = cookie::Cookie::build("session_id")
         .max_age(cookie::time::Duration::seconds(0))
@@ -132,7 +135,11 @@ pub async fn logout_all_handler(session: SessionData) -> Result<impl warp::Reply
         .expect("clear.to_string() returned invalid header‐value");
 
     let reply = warp::reply::with_header("", SET_COOKIE, header_value);
-    log!(LogLevel::Debug, "all sessions logged out for {}", session.user_id);
+    log!(
+        LogLevel::Debug,
+        "all sessions logged out for {}",
+        session.user_id
+    );
     Ok(reply)
 }
 
@@ -140,7 +147,7 @@ pub async fn whoami_handler(session: SessionData) -> Result<impl warp::Reply, wa
     log!(LogLevel::Debug, "whoami for session {}", session.session_id);
     match get_token(session.clone()).await {
         Ok(token) => {
-            let client = Client::new();
+            let client = get_state().http_client.clone();
 
             // First: get user_id
             let response_me = client
@@ -231,7 +238,7 @@ pub async fn me_handler(session: SessionData) -> Result<impl warp::Reply, warp::
     );
     match get_token(session.clone()).await {
         Ok(token) => {
-            let client = Client::new();
+            let client = get_state().http_client.clone();
 
             // First: get user_id
             let response_me = client
@@ -277,7 +284,7 @@ pub async fn runners_handler(session: SessionData) -> Result<impl warp::Reply, w
     );
     match get_token(session.clone()).await {
         Ok(token) => {
-            let client = Client::new();
+            let client = get_state().http_client.clone();
 
             let response = client
                 .get(&format!("{}runners", get_base_url()))
@@ -363,7 +370,7 @@ pub async fn generic_proxy_handler(
         } else {
             TTL_SHORT
         };
-        if let Some(cached) = PROXY_CACHE.get(&cache_key, ttl).await {
+        if let Some(cached) = get_state().proxy_cache.get(&cache_key, ttl).await {
             log!(LogLevel::Debug, "proxy cache hit {}", cache_key);
             let mut resp = Response::new(Body::from(cached.body));
             *resp.status_mut() = warp::http::StatusCode::from_u16(cached.status)
@@ -383,7 +390,7 @@ pub async fn generic_proxy_handler(
         .map_err(|e| warp::reject::custom(Whoops(e.to_string())))?;
 
     // ─── Step 4: Start building the Reqwest request ───────────────────────────
-    let client = Client::new();
+    let client = get_state().http_client.clone();
     let mut req_builder = client
         .request(reqwest_method, &backend_url)
         .bearer_auth(token);
@@ -455,7 +462,8 @@ pub async fn generic_proxy_handler(
     } else {
         log!(LogLevel::Debug, "proxy responded {}", status);
         if method == warp::http::Method::GET && (is_vm || is_runner || is_usage || is_logs) {
-            PROXY_CACHE
+            get_state()
+                .proxy_cache
                 .insert(
                     cache_key,
                     CachedResponse {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -9,8 +9,10 @@ use artisan_middleware::dusa_collection_utils::{
     core::logger::{LogLevel, set_log_level},
     log,
 };
-use database::connection::{init_db_pool, get_db_pool};
-use api::{cache::SESSION_CACHE, cookie::load_active_sessions};
+use database::connection::{get_db_pool, init_db_pool};
+mod state;
+use api::cookie::load_active_sessions;
+use state::{get_state, init_state};
 use warp::Filter;
 // use database::{caching::{orgid_cache_cleaning_loop, permission_cache_cleaning_loop}, connections::init_db_pool};
 // use global::GLOBAL_STATE;
@@ -34,11 +36,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::process::exit(1);
     }
 
+    if let Err(e) = init_state().await {
+        log!(LogLevel::Error, "FATAL STATE INIT ERROR: {}", e);
+        std::process::exit(1);
+    }
+
     match load_active_sessions(get_db_pool()).await {
         Ok(sessions) => {
             let count = sessions.len();
+            let cache = &get_state().session_cache;
             for s in sessions {
-                SESSION_CACHE.insert(s.session_id.clone(), s).await;
+                cache.insert(s.session_id.clone(), s).await;
             }
             log!(LogLevel::Info, "prefilled {} session cache entries", count);
         }
@@ -105,10 +113,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     });
 
-    let routes = api_routes
-        .or(try_html_fallback)
-        .or(static_fs);
-        // .recover(handle_rejection);
+    let routes = api_routes.or(try_html_fallback).or(static_fs);
+    // .recover(handle_rejection);
 
     let http_addr: SocketAddr = "0.0.0.0:3800".parse()?;
     let http_server = tokio::spawn(async move {

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1,0 +1,42 @@
+use once_cell::sync::OnceCell;
+use reqwest::Client;
+
+use crate::{
+    api::cache::{Cache, SessionCache},
+    grpc, // for SecretClient
+};
+use artisan_middleware::dusa_collection_utils::{core::logger::LogLevel, log};
+
+pub struct AppState {
+    pub proxy_cache: Cache,
+    pub session_cache: SessionCache,
+    pub http_client: Client,
+    pub secret_client: grpc::SecretClient,
+}
+
+static APP_STATE: OnceCell<AppState> = OnceCell::new();
+
+pub async fn init_state() -> Result<(), Box<dyn std::error::Error>> {
+    let secret_addr =
+        std::env::var("SECRET_GRPC_ADDR").unwrap_or_else(|_| "http://[::1]:50051".to_string());
+    log!(LogLevel::Info, "connecting to secret gRPC {}", &secret_addr);
+    let secret_client = grpc::SecretClient::connect(secret_addr).await?;
+
+    let state = AppState {
+        proxy_cache: Cache::new(),
+        session_cache: SessionCache::new(),
+        http_client: Client::new(),
+        secret_client,
+    };
+
+    APP_STATE.set(state).map_err(|_| {
+        std::io::Error::new(std::io::ErrorKind::Other, "AppState already initialized")
+    })?;
+
+    log!(LogLevel::Info, "app state initialized");
+    Ok(())
+}
+
+pub fn get_state() -> &'static AppState {
+    APP_STATE.get().expect("AppState not initialized")
+}


### PR DESCRIPTION
## Summary
- manage caches, HTTP client, and gRPC client through new `AppState`
- initialize the shared state on startup
- reuse the HTTP client and gRPC client across handlers

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_6843ef1b8780832db6f40150b44cc8af