### PR TITLE
Integrate frontend secrets with backend API

### DIFF
--- a/backend/src/api/secret.rs
+++ b/backend/src/api/secret.rs
@@ -27,7 +27,19 @@ pub fn secret_routes() -> impl Filter<Extract = impl warp::Reply, Error = warp::
         .and(with_session())
         .and_then(create_handler);
 
-    list.or(create)
+    let update = warp::put()
+        .and(warp::path!("secrets" / "update"))
+        .and(warp::body::json::<secret_service::UpdateSecretRequest>())
+        .and(with_session())
+        .and_then(update_handler);
+
+    let delete = warp::delete()
+        .and(warp::path!("secrets" / "delete"))
+        .and(warp::body::json::<secret_service::DeleteSecretRequest>())
+        .and(with_session())
+        .and_then(delete_handler);
+
+    list.or(create).or(update).or(delete)
 }
 
 async fn list_handler(
@@ -90,6 +102,70 @@ async fn create_handler(
             log!(
                 LogLevel::Error,
                 "create secret failed for {}: {}",
+                session.session_id,
+                e
+            );
+            Err(warp::reject::custom(Whoops(e.to_string())))
+        }
+    }
+}
+
+async fn update_handler(
+    req: secret_service::UpdateSecretRequest,
+    session: crate::api::cookie::SessionData,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    log!(
+        LogLevel::Debug,
+        "update secret {} session {}",
+        req.secret_key,
+        session.session_id
+    );
+    let mut client = get_state().secret_client.clone();
+    match client.update_secret(req).await {
+        Ok(resp) => {
+            log!(
+                LogLevel::Info,
+                "update secret success session {}",
+                session.session_id
+            );
+            Ok(warp::reply::json(&resp))
+        }
+        Err(e) => {
+            log!(
+                LogLevel::Error,
+                "update secret failed for {}: {}",
+                session.session_id,
+                e
+            );
+            Err(warp::reject::custom(Whoops(e.to_string())))
+        }
+    }
+}
+
+async fn delete_handler(
+    req: secret_service::DeleteSecretRequest,
+    session: crate::api::cookie::SessionData,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    log!(
+        LogLevel::Debug,
+        "delete secret {} session {}",
+        req.secret_key,
+        session.session_id
+    );
+    let mut client = get_state().secret_client.clone();
+    match client.delete_secret(req).await {
+        Ok(resp) => {
+            log!(
+                LogLevel::Info,
+                "delete secret success session {}",
+                session.session_id
+            );
+            Ok(warp::reply::json(&resp))
+        }
+        Err(e) => {
+            log!(
+                LogLevel::Error,
+                "delete secret failed for {}: {}",
                 session.session_id,
                 e
             );

--- a/backend/src/grpc/mod.rs
+++ b/backend/src/grpc/mod.rs
@@ -34,4 +34,20 @@ impl SecretClient {
         log!(LogLevel::Debug, "gRPC get_all_secrets");
         Ok(self.client.get_all_secrets(req).await?.into_inner())
     }
+
+    pub async fn update_secret(
+        &mut self,
+        req: secret_service::UpdateSecretRequest,
+    ) -> Result<secret_service::SimpleSecretResponse, tonic::Status> {
+        log!(LogLevel::Debug, "gRPC update_secret");
+        Ok(self.client.update_secret(req).await?.into_inner())
+    }
+
+    pub async fn delete_secret(
+        &mut self,
+        req: secret_service::DeleteSecretRequest,
+    ) -> Result<secret_service::SimpleSecretResponse, tonic::Status> {
+        log!(LogLevel::Debug, "gRPC delete_secret");
+        Ok(self.client.delete_secret(req).await?.into_inner())
+    }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -47,6 +47,58 @@ export async function postWithAuth(endpoint: string, body?: any) {
   return res.json();
 }
 
+export async function putWithAuth(endpoint: string, body?: any) {
+  const opts: RequestInit = {
+    method: "PUT",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  };
+
+  if (body !== undefined) {
+    opts.body = JSON.stringify(body);
+  }
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/${endpoint}`,
+    opts
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`API Error: ${res.status} ${text}`);
+  }
+
+  return res.json();
+}
+
+export async function deleteWithAuth(endpoint: string, body?: any) {
+  const opts: RequestInit = {
+    method: "DELETE",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  };
+
+  if (body !== undefined) {
+    opts.body = JSON.stringify(body);
+  }
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/${endpoint}`,
+    opts
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`API Error: ${res.status} ${text}`);
+  }
+
+  return res.json();
+}
+
 
 export async function fetchBilling(
   usage: UsageSummary

--- a/frontend/src/pages/secrets/index.tsx
+++ b/frontend/src/pages/secrets/index.tsx
@@ -1,21 +1,27 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
+import { Buffer } from 'buffer';
 import { Sidebar } from '@/components/header';
-import { fetchWithAuth } from '@/lib/api';
+import {
+  fetchWithAuth,
+  postWithAuth,
+  putWithAuth,
+  deleteWithAuth,
+} from '@/lib/api';
 import { handleLogout, handleLogoutAll } from '@/lib/logout';
 
 interface SecretItem {
   name: string;
   value: string;
-  env: string;
 }
 
 export default function SecretsPage() {
   const [runnerIds, setRunnerIds] = useState<string[]>([]);
   const [selectedRunner, setSelectedRunner] = useState('');
-  const [secrets, setSecrets] = useState<Record<string, SecretItem[]>>({});
+  const [selectedEnv, setSelectedEnv] = useState('prod');
+  const [customEnv, setCustomEnv] = useState('');
+  const [items, setItems] = useState<SecretItem[]>([]);
   const [newName, setNewName] = useState('');
   const [newValue, setNewValue] = useState('');
-  const [newEnv, setNewEnv] = useState('prod');
 
   useEffect(() => {
     async function loadRunners() {
@@ -33,30 +39,82 @@ export default function SecretsPage() {
     loadRunners();
   }, []);
 
-  const addSecret = () => {
-    if (!newName || !newValue || !selectedRunner) return;
-    const list = secrets[selectedRunner] || [];
-    const updated = {
-      ...secrets,
-      [selectedRunner]: [...list, { name: newName, value: newValue, env: newEnv }],
-    };
-    setSecrets(updated);
-    setNewName('');
-    setNewValue('');
-    setNewEnv('prod');
-    setShowForm(false);
+  const envValue = selectedEnv === '__custom__' ? customEnv : selectedEnv;
+
+  const loadSecrets = useCallback(async () => {
+    if (!selectedRunner || !envValue) {
+      setItems([]);
+      return;
+    }
+    try {
+      const res = await fetchWithAuth(
+        `secrets/list?runner_id=${selectedRunner}&environment_id=${envValue}`
+      );
+      const list: SecretItem[] = (res.vals || []).map((kv: any) => ({
+        name: kv.key,
+        value:
+          typeof atob === 'function'
+            ? atob(kv.value)
+            : Buffer.from(kv.value, 'base64').toString('utf8'),
+      }));
+      setItems(list);
+    } catch (err) {
+      console.error('Failed to load secrets', err);
+    }
+  }, [selectedRunner, envValue]);
+
+  useEffect(() => {
+    loadSecrets();
+  }, [loadSecrets]);
+
+  const addSecret = async () => {
+    if (!newName || !newValue || !selectedRunner || !envValue) return;
+    try {
+      await postWithAuth('secrets/create', {
+        runner_id: selectedRunner,
+        environment_id: envValue,
+        secret_key: newName,
+        value: newValue,
+        actor: 'dashboard',
+      });
+      setNewName('');
+      setNewValue('');
+      loadSecrets();
+    } catch (err) {
+      console.error('Failed to add secret', err);
+    }
   };
 
-  const deleteSecret = (idx: number) => {
-    const list = secrets[selectedRunner] || [];
-    const updated = { ...secrets, [selectedRunner]: list.filter((_, i) => i !== idx) };
-    setSecrets(updated);
+  const deleteSecret = async (name: string) => {
+    if (!selectedRunner || !envValue) return;
+    try {
+      await deleteWithAuth('secrets/delete', {
+        runner_id: selectedRunner,
+        environment_id: envValue,
+        secret_key: name,
+      });
+      loadSecrets();
+    } catch (err) {
+      console.error('Failed to delete secret', err);
+    }
   };
 
-  const changeEnv = (idx: number, env: string) => {
-    const list = secrets[selectedRunner] || [];
-    list[idx] = { ...list[idx], env };
-    setSecrets({ ...secrets, [selectedRunner]: [...list] });
+  const updateSecret = async (name: string, current: string) => {
+    if (!selectedRunner || !envValue) return;
+    const newVal = prompt('Enter new value', current);
+    if (newVal === null) return;
+    try {
+      await putWithAuth('secrets/update', {
+        runner_id: selectedRunner,
+        environment_id: envValue,
+        secret_key: name,
+        new_value: newVal,
+        actor: 'dashboard',
+      });
+      loadSecrets();
+    } catch (err) {
+      console.error('Failed to update secret', err);
+    }
   };
 
   const copySecret = async (value: string) => {
@@ -73,41 +131,53 @@ export default function SecretsPage() {
       <main className="flex-1 p-4 sm:p-6 lg:p-8">
         <h1 className="text-3xl font-bold text-brand mb-6">Secrets</h1>
 
-        <div className="mb-6">
-          <label className="block text-sm font-medium mb-1">Select Runner</label>
-          <select
-            className="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700"
-            value={selectedRunner}
-            onChange={(e) => setSelectedRunner(e.target.value)}
-          >
-            {runnerIds.map((id) => (
-              <option key={id} value={id}>
-                {id}
-              </option>
-            ))}
-          </select>
+        <div className="mb-6 grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium mb-1">Select Runner</label>
+            <select
+              className="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700"
+              value={selectedRunner}
+              onChange={(e) => setSelectedRunner(e.target.value)}
+            >
+              {runnerIds.map((id) => (
+                <option key={id} value={id}>
+                  {id}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Select Environment</label>
+            <select
+              className="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700"
+              value={selectedEnv}
+              onChange={(e) => setSelectedEnv(e.target.value)}
+            >
+              <option value="dev">dev</option>
+              <option value="stage">stage</option>
+              <option value="prod">prod</option>
+              <option value="__custom__">Custom...</option>
+            </select>
+            {selectedEnv === '__custom__' && (
+              <input
+                className="mt-2 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700"
+                placeholder="Environment name"
+                value={customEnv}
+                onChange={(e) => setCustomEnv(e.target.value)}
+              />
+            )}
+          </div>
         </div>
+
         <div className="card p-6 space-y-6">
-          {selectedRunner && (secrets[selectedRunner] || []).length === 0 ? (
+          {selectedRunner && items.length === 0 ? (
             <p className="text-gray-500">No secrets stored yet.</p>
           ) : (
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {(secrets[selectedRunner] || []).map((s, idx) => (
-                <div key={idx} className="card-hover p-4 space-y-2">
+              {items.map((s) => (
+                <div key={s.name} className="card-hover p-4 space-y-2">
                   <p className="font-semibold text-brand">{s.name}</p>
                   <p className="text-sm text-gray-400 truncate">{s.value}</p>
-                  <div className="flex items-center gap-2">
-                    <label className="text-xs">Env:</label>
-                    <select
-                      className="border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700 text-sm"
-                      value={s.env}
-                      onChange={(e) => changeEnv(idx, e.target.value)}
-                    >
-                      <option value="dev">dev</option>
-                      <option value="stage">stage</option>
-                      <option value="prod">prod</option>
-                    </select>
-                  </div>
                   <div className="mt-2 flex gap-2">
                     <button
                       onClick={() => copySecret(s.value)}
@@ -116,7 +186,13 @@ export default function SecretsPage() {
                       Copy
                     </button>
                     <button
-                      onClick={() => deleteSecret(idx)}
+                      onClick={() => updateSecret(s.name, s.value)}
+                      className="bg-blue-600 text-white px-3 py-1 rounded text-sm hover:bg-blue-700"
+                    >
+                      Update
+                    </button>
+                    <button
+                      onClick={() => deleteSecret(s.name)}
                       className="bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700"
                     >
                       Delete
@@ -129,7 +205,7 @@ export default function SecretsPage() {
 
           <div className="border-t border-gray-300 dark:border-gray-700 pt-4">
             <h3 className="font-semibold text-brand mb-2">Add Secret</h3>
-            <div className="grid gap-4 sm:grid-cols-3 mb-4">
+            <div className="grid gap-4 sm:grid-cols-2 mb-4">
               <input
                 id="name"
                 placeholder="Name"
@@ -144,16 +220,6 @@ export default function SecretsPage() {
                 onChange={(e) => setNewValue(e.target.value)}
                 className="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700"
               />
-              <select
-                id="env"
-                value={newEnv}
-                onChange={(e) => setNewEnv(e.target.value)}
-                className="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700"
-              >
-                <option value="dev">dev</option>
-                <option value="stage">stage</option>
-                <option value="prod">prod</option>
-              </select>
             </div>
             <button
               onClick={addSecret}
@@ -166,8 +232,5 @@ export default function SecretsPage() {
       </main>
     </div>
   );
-}
-function setShowForm(arg0: boolean) {
-  throw new Error('Function not implemented.');
 }
 


### PR DESCRIPTION
## Summary
- add gRPC client support for updating and deleting secrets
- expose CRUD HTTP routes for secrets
- wire secrets page to backend and allow custom environment selection

## Testing
- `npm run lint` (fails: prompts for ESLint configuration)
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688fa340af20832d9cb562f59b028791