### PR TITLE
Route frontend API calls through Rust backend proxy

### DIFF
--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -14,7 +14,7 @@ use super::{
 
 pub async fn create_api_routes() -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     log!(LogLevel::Debug, "creating API routes");
-    let testing_origin = "http://localhost:3800";
+    let testing_origin = "http://localhost:3000";
     let release = "https://dashboard.artisanhosting.net";
 
     let cors = warp::cors()

--- a/frontend/src/hooks/useUser.ts
+++ b/frontend/src/hooks/useUser.ts
@@ -1,5 +1,6 @@
 // /hooks/useUser.ts
 import { useState, useEffect } from 'react'
+import { BACKEND_URL } from '@/lib/config'
 
 export function useUser() {
     const [username, setUsername] = useState<string>('')
@@ -12,7 +13,7 @@ export function useUser() {
 
         async function fetchUser() {
             try {
-                const meRes = await fetch(`${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/auth/me`, {
+                const meRes = await fetch(`${BACKEND_URL}/auth/me`, {
                     method: 'GET',
                     credentials: "include", // ← send the cookie
                     headers: {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,9 +1,10 @@
 // src/lib/api.ts
 import { BillingCosts, RefreshRequest, RefreshResponse, UsageSummary, VmActionRequest, VmActionType, VmListItem, VmStatusDetail } from "./types";
+import { BACKEND_URL } from "./config";
 
 export async function fetchWithAuth(endpoint: string) {
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/${endpoint}`,
+    `${BACKEND_URL}/${endpoint}`,
     {
       method: "GET",
       credentials: "include", // ← send the server‐issued cookie
@@ -35,7 +36,7 @@ export async function postWithAuth(endpoint: string, body?: any) {
   }
 
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/${endpoint}`,
+    `${BACKEND_URL}/${endpoint}`,
     opts
   );
 
@@ -61,7 +62,7 @@ export async function putWithAuth(endpoint: string, body?: any) {
   }
 
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/${endpoint}`,
+    `${BACKEND_URL}/${endpoint}`,
     opts
   );
 
@@ -87,7 +88,7 @@ export async function deleteWithAuth(endpoint: string, body?: any) {
   }
 
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/${endpoint}`,
+    `${BACKEND_URL}/${endpoint}`,
     opts
   );
 
@@ -104,7 +105,7 @@ export async function fetchBilling(
   usage: UsageSummary
 ): Promise<BillingCosts> {
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/proxy/billing/calculate?instances=${usage.instances}`,
+    `${BACKEND_URL}/proxy/billing/calculate?instances=${usage.instances}`,
     {
       method: "POST",
       credentials: "include", // ← send the cookie

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,0 +1,5 @@
+// Base URL for the Rust backend proxy
+// Frontend should only call this service; the Rust backend in turn
+// contacts the upstream https://api.artisanhosting.net/v1 API.
+// Includes the `/api` prefix expected by the Rust server.
+export const BACKEND_URL = "http://localhost:3800/api";

--- a/frontend/src/lib/logout.ts
+++ b/frontend/src/lib/logout.ts
@@ -1,7 +1,8 @@
 import router from "next/router";
+import { BACKEND_URL } from "./config";
 
 export async function handleLogout() {
-    await fetch(`${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/auth/logout`, {
+    await fetch(`${BACKEND_URL}/auth/logout`, {
         method: "POST",
         credentials: "include",
     });
@@ -9,7 +10,7 @@ export async function handleLogout() {
 }
 
 export async function handleLogoutAll() {
-    await fetch(`${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/auth/logout_all`, {
+    await fetch(`${BACKEND_URL}/auth/logout_all`, {
         method: "POST",
         credentials: "include",
     });

--- a/frontend/src/pages/account.tsx
+++ b/frontend/src/pages/account.tsx
@@ -5,6 +5,7 @@ import { useUser } from '@/hooks/useUser'
 import { Sidebar } from '@/components/header'
 import LoadingOverlay from '@/components/loading'
 import { handleLogout, handleLogoutAll } from '@/lib/logout'
+import { BACKEND_URL } from '@/lib/config'
 
 export default function AccountPage() {
   const { username, email: loadedEmail, isLoading, error } = useUser()
@@ -19,7 +20,7 @@ export default function AccountPage() {
   const handleUpdateEmail = async () => {
     try {
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/account/email`,
+        `${BACKEND_URL}/account/email`,
         {
           method: 'PUT',
           credentials: 'include',
@@ -46,7 +47,7 @@ export default function AccountPage() {
     }
     try {
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/account/password`,
+        `${BACKEND_URL}/account/password`,
         {
           method: 'PUT',
           credentials: 'include',

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { jwtDecode } from "jwt-decode";
 import logo from "../img/logo.webp";
 import LoadingOverlay from "@/components/loading";
+import { BACKEND_URL } from "@/lib/config";
 
 export default function LoginPage() {
     const router = useRouter();
@@ -13,7 +14,7 @@ export default function LoginPage() {
 
     useEffect(() => {
         // This effect will run only once, on mount
-        fetch(`${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/auth/whoami`, {
+        fetch(`${BACKEND_URL}/auth/whoami`, {
             method: "GET",
             credentials: "include",
         })
@@ -39,7 +40,7 @@ export default function LoginPage() {
         e.preventDefault();
 
         const res = await fetch(
-            `${process.env.NEXT_PUBLIC_PRIMARY_API_URL}/auth/login`,
+            `${BACKEND_URL}/auth/login`,
             {
                 method: "POST",
                 credentials: "include",            // ← tell the browser to accept & store the Set-Cookie


### PR DESCRIPTION
## Summary
- add `BACKEND_URL` constant documenting the Rust proxy for Artisan Hosting API
- update frontend hooks, utilities, and pages to use `BACKEND_URL`

## Testing
- `cargo test`
- `npm test` (fails: Missing script)
- `npm run lint` (prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_688fa360f668832da1eefaa7c9b93056